### PR TITLE
Update numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dash==2.3.1
-numpy==1.19.4
+numpy==1.20.3
 pandas==1.4.2
 plotly==5.7.0
 scikit-learn==1.0.2


### PR DESCRIPTION
DSE-29129: test_amps_Active_Learning failing in weekly run with "matplotlib 3.7.0 requires numpy>=1.20, but you have numpy 1.19.4 which is incompatible"
I have verified on mow-dev that it works with numpy version 1.20.3.